### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ name: Release policy
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       artifacthub: false
 
@@ -24,7 +24,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/tests/raw-mutation-policy
       artifacthub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
-    with:
-      artifacthub: false
 
   release:
     needs: test
@@ -27,4 +25,3 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/tests/raw-mutation-policy
-      artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,5 +4,3 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
-    with:
-      artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       artifacthub: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SOURCE_FILES := $(shell find . -type f -name '*.go')
-# It's necessary to call cut because kwctl command does not handle version
-# starting with v.
 VERSION ?= $(shell git describe | cut -c2-)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SOURCE_FILES := $(shell find . -type f -name '*.go')
-VERSION ?= $(shell git describe | cut -c2-)
-
 
 policy.wasm: $(SOURCE_FILES) go.mod go.sum
 	docker run \

--- a/metadata.yml
+++ b/metadata.yml
@@ -11,6 +11,7 @@ backgroundAudit: true
 annotations:
   # kubewarden specific:
   io.kubewarden.policy.title: raw-mutation-policy
+  io.kubewarden.policy.version: 
   io.kubewarden.policy.description: A policy that mutates raw requests
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/raw-mutation-policy

--- a/metadata.yml
+++ b/metadata.yml
@@ -11,7 +11,7 @@ backgroundAudit: true
 annotations:
   # kubewarden specific:
   io.kubewarden.policy.title: raw-mutation-policy
-  io.kubewarden.policy.version: 
+  io.kubewarden.policy.version: 0.0.1-unreleased
   io.kubewarden.policy.description: A policy that mutates raw requests
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/raw-mutation-policy


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
Co-authored-by: Flavio Castelli <fcastelli@suse.com>
